### PR TITLE
Add execution manual, API docs, service tests and docker compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/node_modules
-/target
+node_modules/
+target/

--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ Se você for aprovad(a) nesta etapa, será convidado para uma entrevista final.
       3. Desenvolva. Você terá 7 (sete) dias a partir da data do envio do desafio; 
       4. Após concluir seu trabalho faça um push; 
       5. Envie um e-mail à pessoa que está mantendo o contato com você durante o processo notificando a finalização do desafio para validação.
+
+## Documentação
+
+- [Manual de Execução](docs/manual.md)
+- [Documentação da API](docs/api.md)

--- a/backend/src/test/java/com/example/banking/service/AccountServiceTest.java
+++ b/backend/src/test/java/com/example/banking/service/AccountServiceTest.java
@@ -1,0 +1,85 @@
+package com.example.banking.service;
+
+import com.example.banking.dto.OperationRequest;
+import com.example.banking.model.Account;
+import com.example.banking.model.Transaction;
+import com.example.banking.repository.AccountRepository;
+import com.example.banking.repository.PersonRepository;
+import com.example.banking.repository.TransactionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountServiceTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+    @Mock
+    private PersonRepository personRepository;
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @InjectMocks
+    private AccountService service;
+
+    @Test
+    void depositShouldIncreaseBalanceAndPersistTransaction() {
+        Account account = new Account();
+        account.setIdConta(1L);
+        account.setSaldo(BigDecimal.valueOf(100));
+        account.setFlagAtivo(true);
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+
+        OperationRequest request = new OperationRequest();
+        request.setValor(BigDecimal.valueOf(50));
+
+        service.deposit(1L, request);
+
+        assertEquals(BigDecimal.valueOf(150), account.getSaldo());
+        verify(accountRepository).save(account);
+
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionRepository).save(captor.capture());
+        assertEquals(BigDecimal.valueOf(50), captor.getValue().getValor());
+        assertEquals(account, captor.getValue().getConta());
+    }
+
+    @Test
+    void withdrawShouldThrowWhenInsufficientBalance() {
+        Account account = new Account();
+        account.setIdConta(1L);
+        account.setSaldo(BigDecimal.valueOf(10));
+        account.setFlagAtivo(true);
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+
+        OperationRequest request = new OperationRequest();
+        request.setValor(BigDecimal.valueOf(20));
+
+        assertThrows(IllegalStateException.class, () -> service.withdraw(1L, request));
+        verify(accountRepository, never()).save(any());
+        verify(transactionRepository, never()).save(any());
+    }
+
+    @Test
+    void blockShouldDeactivateAccount() {
+        Account account = new Account();
+        account.setIdConta(1L);
+        account.setFlagAtivo(true);
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+
+        service.block(1L);
+
+        assertFalse(account.getFlagAtivo());
+        verify(accountRepository).save(account);
+    }
+}

--- a/database/docker-compose.yml
+++ b/database/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: mssql-bank
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=YourStrong!Passw0rd
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssql_bank_data:/var/opt/mssql
+    networks:
+      - banking-net
+
+  sqlpad:
+    image: sqlpad/sqlpad:latest
+    container_name: sqlpad
+    environment:
+      - SQLPAD_ADMIN=admin@example.com
+      - SQLPAD_ADMIN_PASSWORD=Admin123!
+    ports:
+      - "3050:3000"
+    depends_on:
+      - mssql
+    networks:
+      - banking-net
+
+volumes:
+  mssql_bank_data:
+
+networks:
+  banking-net:

--- a/database/readme.txt
+++ b/database/readme.txt
@@ -1,7 +1,13 @@
-docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=YourStrong!Passw0rd' \
-  -p 1433:1433 --name mssql-bank -d \
-  -v mssql_bank_data:/var/opt/mssql \
-  mcr.microsoft.com/mssql/server:2022-latest
- 
- comandos para criar o sql server
- 
+Use o Docker Compose para subir o banco de dados e o SQLPad:
+
+```bash
+docker compose up -d
+```
+
+O arquivo `docker-compose.yml` define os serviços `mssql` e `sqlpad`.
+
+Após subir os contêineres, carregue o esquema inicial:
+
+```bash
+sqlcmd -S localhost -U sa -P YourStrong!Passw0rd -i schema.sql
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,47 @@
+# Documentação da API
+
+## Criar conta
+`POST /contas`
+
+Corpo da requisição:
+```json
+{
+  "nome": "João",
+  "cpf": "12345678901",
+  "dataNascimento": "1990-01-01",
+  "limiteSaqueDiario": 100.00,
+  "tipoConta": 1
+}
+```
+
+## Depositar
+`POST /contas/{id}/deposito`
+
+Corpo:
+```json
+{
+  "valor": 50.00
+}
+```
+
+## Consultar saldo
+`GET /contas/{id}/saldo`
+
+## Sacar
+`POST /contas/{id}/saque`
+
+Corpo:
+```json
+{
+  "valor": 20.00
+}
+```
+
+## Bloquear conta
+`POST /contas/{id}/bloqueio`
+
+## Extrato
+`GET /contas/{id}/extrato?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD`
+
+## Consultar conta
+`GET /contas/{id}`

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,0 +1,73 @@
+# Manual de Execução
+
+## Requisitos
+- Java 17
+- Maven
+- Node.js 18 e npm
+- Docker e Docker Compose
+
+## Banco de Dados
+1. Na pasta `database`, utilize o Docker Compose para subir o SQL Server e o SQLPad:
+   ```yaml
+   services:
+     mssql:
+       image: mcr.microsoft.com/mssql/server:2022-latest
+       container_name: mssql-bank
+       environment:
+         - ACCEPT_EULA=Y
+         - SA_PASSWORD=YourStrong!Passw0rd
+       ports:
+         - "1433:1433"
+       volumes:
+         - mssql_bank_data:/var/opt/mssql
+       networks:
+         - banking-net
+
+     sqlpad:
+       image: sqlpad/sqlpad:latest
+       container_name: sqlpad
+       environment:
+         - SQLPAD_ADMIN=admin@example.com
+         - SQLPAD_ADMIN_PASSWORD=Admin123!
+       ports:
+         - "3050:3000"
+       depends_on:
+         - mssql
+       networks:
+         - banking-net
+
+   volumes:
+     mssql_bank_data:
+
+   networks:
+     banking-net:
+   ```
+2. Execute `docker compose up -d` dentro da pasta `database`.
+3. Carregue o esquema inicial:
+   ```bash
+   sqlcmd -S localhost -U sa -P YourStrong!Passw0rd -i database/schema.sql
+   ```
+
+## Backend
+1. Acesse a pasta `backend`.
+2. Execute a aplicação:
+   ```bash
+   mvn spring-boot:run
+   ```
+3. A API estará disponível em `http://localhost:8080`.
+
+## Frontend
+1. Acesse a pasta `frontend`.
+2. Instale as dependências e execute:
+   ```bash
+   npm install
+   npm start
+   ```
+3. A interface estará disponível em `http://localhost:4200`.
+
+## Testes
+Para executar os testes automatizados do backend:
+```bash
+cd backend
+mvn test
+```


### PR DESCRIPTION
## Summary
- add manual with instructions to run database via docker compose, backend, frontend and tests
- document API endpoints
- include unit tests for account service operations
- provide docker-compose config and update database docs

## Testing
- `mvn test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c03904651c83309d1513bc4f30b31c