### PR TITLE
Support CPF-based account lookup with UI redirects

### DIFF
--- a/backend/src/main/java/com/example/banking/controller/AccountController.java
+++ b/backend/src/main/java/com/example/banking/controller/AccountController.java
@@ -62,4 +62,9 @@ public class AccountController {
     public ResponseEntity<Account> getAccount(@PathVariable Long id) {
         return ResponseEntity.ok(service.getAccount(id));
     }
+
+    @GetMapping("/cpf/{cpf}")
+    public ResponseEntity<Long> getAccountIdByCpf(@PathVariable String cpf) {
+        return ResponseEntity.ok(service.getAccountIdByCpf(cpf));
+    }
 }

--- a/backend/src/main/java/com/example/banking/repository/AccountRepository.java
+++ b/backend/src/main/java/com/example/banking/repository/AccountRepository.java
@@ -3,5 +3,8 @@ package com.example.banking.repository;
 import com.example.banking.model.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AccountRepository extends JpaRepository<Account, Long> {
+    Optional<Account> findByPessoaCpf(String cpf);
 }

--- a/backend/src/main/java/com/example/banking/service/AccountService.java
+++ b/backend/src/main/java/com/example/banking/service/AccountService.java
@@ -115,4 +115,10 @@ public class AccountService {
         return accountRepository.findById(idConta)
                 .orElseThrow(() -> new IllegalArgumentException("Conta não encontrada"));
     }
+
+    public Long getAccountIdByCpf(String cpf) {
+        Account account = accountRepository.findByPessoaCpf(cpf)
+                .orElseThrow(() -> new IllegalArgumentException("Conta não encontrada"));
+        return account.getIdConta();
+    }
 }

--- a/frontend/src/app/account.component.ts
+++ b/frontend/src/app/account.component.ts
@@ -39,14 +39,26 @@ export class AccountComponent {
   deposit() {
     if (this.depositValue != null) {
       this.http.post(`http://localhost:8080/contas/${this.accountId}/deposito`, { valor: this.depositValue })
-        .subscribe(() => this.loadBalance());
+        .subscribe({
+          next: () => {
+            this.loadBalance();
+            alert('Depósito realizado com sucesso');
+          },
+          error: () => alert('Erro ao realizar depósito')
+        });
     }
   }
 
   withdraw() {
     if (this.withdrawValue != null) {
       this.http.post(`http://localhost:8080/contas/${this.accountId}/saque`, { valor: this.withdrawValue })
-        .subscribe(() => this.loadBalance());
+        .subscribe({
+          next: () => {
+            this.loadBalance();
+            alert('Saque realizado com sucesso');
+          },
+          error: () => alert('Erro ao realizar saque')
+        });
     }
   }
 
@@ -56,6 +68,12 @@ export class AccountComponent {
     if (this.endDate) params.push(`endDate=${this.endDate}`);
     const query = params.length ? '?' + params.join('&') : '';
     this.http.get<any[]>(`http://localhost:8080/contas/${this.accountId}/extrato${query}`)
-      .subscribe(t => this.transactions = t);
+      .subscribe({
+        next: t => {
+          this.transactions = t;
+          alert('Extrato carregado');
+        },
+        error: () => alert('Erro ao carregar extrato')
+      });
   }
 }

--- a/frontend/src/app/create-account.component.html
+++ b/frontend/src/app/create-account.component.html
@@ -24,7 +24,6 @@
       </mat-form-field>
       <button mat-raised-button color="primary" type="submit">Criar</button>
     </form>
-    <div *ngIf="createdId">Conta criada com ID {{ createdId }}</div>
     <p><a routerLink="/">Voltar</a></p>
   </mat-card>
 </div>

--- a/frontend/src/app/create-account.component.ts
+++ b/frontend/src/app/create-account.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
@@ -24,12 +24,17 @@ interface CreateAccountRequest {
 })
 export class CreateAccountComponent {
   account: CreateAccountRequest = { nome: '', cpf: '', dataNascimento: '', limiteSaqueDiario: 0, tipoConta: 1 };
-  createdId?: number;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private router: Router) {}
 
   create() {
     this.http.post<any>('http://localhost:8080/contas', this.account)
-      .subscribe(res => this.createdId = res.id);
+      .subscribe({
+        next: () => {
+          alert('Conta criada com sucesso');
+          this.router.navigate(['/']);
+        },
+        error: () => alert('Erro ao criar conta')
+      });
   }
 }

--- a/frontend/src/app/login.component.ts
+++ b/frontend/src/app/login.component.ts
@@ -6,6 +6,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-login',
@@ -16,11 +17,18 @@ import { MatCardModule } from '@angular/material/card';
 export class LoginComponent {
   cpf = '';
 
-  constructor(private router: Router) {}
+  constructor(private http: HttpClient, private router: Router) {}
 
   login() {
     if (this.cpf) {
-      this.router.navigate(['/account', this.cpf]);
+      this.http.get<number>(`http://localhost:8080/contas/cpf/${this.cpf}`)
+        .subscribe({
+          next: id => {
+            alert('Login realizado com sucesso');
+            this.router.navigate(['/account', id]);
+          },
+          error: () => alert('Conta não encontrada')
+        });
     }
   }
 }


### PR DESCRIPTION
## Summary
- expose API to fetch account ID by CPF
- wire front-end login and operations to use ID and show alerts

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: No provider for framework:@angular-devkit/build-angular)*

------
https://chatgpt.com/codex/tasks/task_e_68c04964a6f88330a6187f64aa0df412